### PR TITLE
Add a catkin_make hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Modified from https://frankcorso.dev/automatically-run-build-scripts-switching-branches-git-hooks.html
+#
+if [ "$3" = '1' ]
+then
+    cd "../.."
+    catkin_make
+fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Introduction
 This is a repository for the `rosardvarc` ROS package.
+
 ## Installation
 This package requires a valid installation of ROS. For ROS installation details, see [the ROS installation page](https://wiki.ros.org/ROS/Installation) or the [single-line ROS installation](https://wiki.ros.org/ROS/Installation/TwoLineInstall). Then follow the start of [this ROS environment setup tutorial](https://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment) to make a catkin workspace.
 
@@ -15,4 +16,19 @@ Once the repo is cloned, run the following command to build the package:
 cd ~/catkin_ws && catkin_make
 ```
 
+## Stay Up To Date
+To automatically re-run `catkin_make` whenever you change branches, first ensure that your version of git supports git hooks by running:
+```
+sudo add-apt-repository -y ppa:git-core/ppa
+sudo apt-get update
+sudo apt-get install git -y
+```
+
+Then, run the following command:
+```
+cd ~/catkin_ws/src/rosardvarc
+git config --local core.hooksPath .githooks/
+```
+
+## Learn More
 For more details on the ARDVARC project, see [the core project repo](https://github.com/ARDVARC/ARDVARC).


### PR DESCRIPTION
Adds a git hook to automatically run `catkin_make` whenever you checkout a new branch locally. We may want to trigger it other times too but we can add that later.

The README is also updated to describe how to set up the hook. I've tried to make it as simple as possible (just coping and pasting some commands) but it does require a bit of setup.