### PR TITLE
Remove Go Home state

### DIFF
--- a/msg/MissionState.msg
+++ b/msg/MissionState.msg
@@ -40,11 +40,6 @@ uint8 LOCALIZE_RGV_2 = 5
 # field of view.
 uint8 JOINT_LOCALIZE = 6
 
-# In this state the flight software will be generating
-# setpoints to guide the drone outside of the mission area
-# back towards the home base.
-uint8 GO_HOME = 7
-
 ## Fields
 # The time that this mission state is for
 time timestamp

--- a/msg/StateMachineCriteria.msg
+++ b/msg/StateMachineCriteria.msg
@@ -46,7 +46,3 @@ bool rgv_2_sighted
 # state, where this TBD is less than the TBD in rgv_1_localized and
 # rgv_2_localized
 bool minimum_localize_time_reached
-
-# Battery is below TBD %, where TBD is a small value but enough to
-# definitely return to the home base
-bool battery_low


### PR DESCRIPTION
## Changes

Removes the `Go Home` state from the state machine messages. See discussion under [`ARDVARC` PR #116](https://github.com/ARDVARC/ARDVARC/issues/110).

Note: This PR goes with [`ARDVARC` PR #117](https://github.com/ARDVARC/ARDVARC/pull/117)